### PR TITLE
Adding support for cupy.cuda.stream.ExternalStream

### DIFF
--- a/python/rmm/rmm/_cuda/stream.pyx
+++ b/python/rmm/rmm/_cuda/stream.pyx
@@ -100,7 +100,7 @@ cdef class Stream:
     def _init_from_cupy_stream(self, obj):
         try:
             import cupy
-            if isinstance(obj, cupy.cuda.stream.Stream):
+            if isinstance(obj, (cupy.cuda.stream.Stream, cupy.cuda.stream.ExternalStream)):
                 self._cuda_stream = <cudaStream_t><uintptr_t>(obj.ptr)
                 self._owner = obj
                 return


### PR DESCRIPTION
## Description
Cupy offers the `cupy.cuda.stream.ExternalStream` for utilizing external CUDA streams. Moreover, `cupy.cuda.get_current_stream()` will return an instance of `cupy.cuda.stream.ExternalStream` instead of `cupy.cuda.stream.Stream`, particularly when the current cuPy stream has been changed.

Therefore, we must verify both types of instances to avoid errors.

See details in the https://docs.cupy.dev/en/stable/user_guide/interoperability.html#cuda-stream-pointers

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
